### PR TITLE
Fix flaky AuthController authentication test

### DIFF
--- a/tests/Feature/Http/Controllers/API/AuthControllerTest.php
+++ b/tests/Feature/Http/Controllers/API/AuthControllerTest.php
@@ -101,10 +101,12 @@ class AuthControllerTest extends TestCase
 
     public function test_authenticate_endpoint_returns_status_200_when_provided_valid_credentials(): void
     {
-        $auth = $this->authenticate([
+        $credentials = [
             'email' => $this->faker->safeEmail,
-            'password' => $this->faker->password,
-        ]);
+            'password' => 'password', // Use a fixed password to ensure consistency
+        ];
+
+        $auth = $this->authenticate($credentials);
 
         $auth->assertStatus(200)
             ->assertJsonStructure($this->authenticatedUserResponseStructure);


### PR DESCRIPTION
## Summary
- Fixed intermittent test failure in `test_authenticate_endpoint_returns_status_200_when_provided_valid_credentials`
- Replaced random password generation with consistent password to prevent credential mismatch

## Test plan
- [x] Run AuthController test suite - all 20 tests pass
- [x] Verify specific test runs consistently without flakiness